### PR TITLE
The EXTRA_LDFLAGS was empty 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 default: plugins/krakend-server-example.so
-	docker run --platform linux/arm64 --rm -p "8080:8080" -v ${PWD}:/etc/krakend/ devopsfaith/krakend:2.1.4
+	docker run --platform linux/arm64 --rm -p "8080:8080" -v ${PWD}:/etc/krakend/ devopsfaith/krakend:2.3.2
 
+EXTRA_LDFLAGS := "-extldflags=-fuse-ld=bfd -extld=aarch64-linux-musl-gcc"
 plugins/krakend-server-example.so: 
 	mkdir -p plugins
 	docker run --rm -it -v "${PWD}:/app" -w /app \
@@ -8,9 +9,8 @@ plugins/krakend-server-example.so:
 	-e CC=aarch64-linux-musl-gcc \
 	-e GOARCH=arm64 \
 	-e GOHOSTARCH=amd64 \
-	-e EXTRA_LDFLAGS='-extldflags=-fuse-ld=bfd -extld=aarch64-linux-musl-gcc' \
-	krakend/builder:2.1.4 \
-	go build -ldflags="${EXTRA_LDFLAGS}" -buildmode=plugin -o plugins/krakend-server-example.so .	
+	krakend/builder:2.3.2 \
+	go build -ldflags=${EXTRA_LDFLAGS} -buildmode=plugin -o plugins/krakend-server-example.so .
 
 clean:
 	-rm -rf plugins


### PR DESCRIPTION
since the defined variable comes from the Makefile, not the ENV.
Also, 2.3.2 will fix a problem when loading ARM64 plugins.